### PR TITLE
Add basic IPv6 support

### DIFF
--- a/robot-detect
+++ b/robot-detect
@@ -14,6 +14,7 @@ import os
 import argparse
 import ssl
 import gmpy2
+import ipaddress
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 
@@ -34,16 +35,13 @@ MSG_FASTOPEN = 0x20000000
 EXECUTE_BLINDING = True
 
 
-def get_rsa_from_server(server, port):
+def get_rsa_from_server(connection):
     try:
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
         ctx.set_ciphers("RSA")
-        raw_socket = socket.socket()
-        raw_socket.settimeout(timeout)
-        s = ctx.wrap_socket(raw_socket)
-        s.connect((server, port))
+        s = ctx.wrap_socket(connection)
         cert_raw = s.getpeercert(binary_form=True)
         cert_dec = x509.load_der_x509_certificate(cert_raw, default_backend())
         s.close()
@@ -69,13 +67,13 @@ def get_rsa_from_server(server, port):
 def oracle(pms, messageflow=False):
     global cke_version
     try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s = socket.socket(ip_family, socket.SOCK_STREAM)
         s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         if not enable_fastopen:
-            s.connect((ip, args.port))
+            s.connect(server)
             s.sendall(ch)
         else:
-            s.sendto(ch, MSG_FASTOPEN, (ip, args.port))
+            s.sendto(ch, MSG_FASTOPEN, server)
         s.settimeout(timeout)
         buf = bytearray.fromhex("")
         i = 0
@@ -184,8 +182,12 @@ else:
 # We only enable TCP fast open if the Linux proc interface exists
 enable_fastopen = os.path.exists("/proc/sys/net/ipv4/tcp_fastopen")
 
+server = (args.host, args.port)
+
 try:
-    ip = socket.gethostbyname(args.host)
+    connection = socket.create_connection(server, timeout=timeout)
+    ip = connection.getpeername()[0]
+    ip_family = socket.AF_INET if ipaddress.ip_address(ip).version == 4 else socket.AF_INET6
 except socket.gaierror as e:
     if not args.quiet:
         print("Cannot resolve host: %s" % e)
@@ -193,12 +195,19 @@ except socket.gaierror as e:
         print("NODNS,%s,,,,,,,,," % (args.host))
 
     quit()
+except ConnectionRefusedError as e:
+    if not args.quiet:
+        print("Connection refused: %s" % e)
+    if args.csv:
+        print("CONNECTIONREFUSED,%s,,,,,,,,," % (args.host))
+
+    quit()
 
 
 if not args.quiet:
     print("Scanning host %s ip %s port %i" % (args.host, ip, args.port))
 
-N, e = get_rsa_from_server(ip, args.port)
+N, e = get_rsa_from_server(connection)
 modulus_bits = int(math.ceil(math.log(N, 2)))
 modulus_bytes = (modulus_bits + 7) // 8
 if not args.quiet:


### PR DESCRIPTION
As of now, the `robot-detect` script does not allow testing for the ROBOT vulnerability on IPv6 addresses. With this pull request, I am adding a basic IPv6 support changing the current code as little as possible.
This PR tries to follow the code-style as much as possible and barely changes any logic.

Any comment is very welcome :) 